### PR TITLE
refactor(api): move product service to public endpoint

### DIFF
--- a/HMA_AS/urls.py
+++ b/HMA_AS/urls.py
@@ -22,6 +22,7 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('i18n/', include('django.conf.urls.i18n')),
+    path('api/public/', include('products.api_urls')),
     path('', include('core.urls')),
     path('accounts/', include('accounts.urls')),
     path('shop/', include('products.urls')),

--- a/README.md
+++ b/README.md
@@ -116,6 +116,54 @@ HMA_AS/
 
 ---
 
+## Servicio web JSON para equipos aliados
+
+La aplicación expone un servicio web público en formato JSON para que otros equipos puedan consumir información relevante del ecommerce y mostrarla en sus propias vistas.
+
+### Endpoints
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| `GET` | `/api/public/products/` | Lista productos activos del ecommerce |
+| `GET` | `/api/public/products/<slug>/` | Consulta el detalle de un producto activo |
+
+### Filtros soportados
+
+El listado acepta los mismos filtros principales del catálogo:
+
+| Parámetro | Ejemplo | Descripción |
+|-----------|---------|-------------|
+| `q` | `/api/public/products/?q=shirt` | Busca por nombre o descripción |
+| `category` | `/api/public/products/?category=t-shirts` | Filtra por slug de categoría |
+| `size` | `/api/public/products/?size=M` | Filtra productos con stock disponible en una talla |
+| `min_price` | `/api/public/products/?min_price=50000` | Precio mínimo |
+| `max_price` | `/api/public/products/?max_price=150000` | Precio máximo |
+| `sort` | `/api/public/products/?sort=price_asc` | Ordena por `newest`, `price_asc` o `price_desc` |
+
+### Ejemplo de respuesta
+
+```json
+{
+  "results": [
+    {
+      "id": 1,
+      "name": "Classic T-Shirt",
+      "slug": "classic-t-shirt",
+      "description": "Basic cotton t-shirt.",
+      "price": "85000.00",
+      "brand": "HMA",
+      "category": "T-Shirts",
+      "image_url": "http://localhost:8000/media/productos/classic.jpg",
+      "detail_url": "http://localhost:8000/api/public/products/classic-t-shirt/"
+    }
+  ]
+}
+```
+
+Las URLs de imagen y detalle se entregan como URLs absolutas para facilitar el consumo desde aplicaciones externas.
+
+---
+
 ## Cómo ejecutar el proyecto
 
 ### Requisitos previos

--- a/products/api_serializers.py
+++ b/products/api_serializers.py
@@ -1,0 +1,80 @@
+from django.urls import reverse
+
+from .constants import SIZE_ORDER
+
+
+class ProductApiSerializer:
+    """Convierte productos en estructuras JSON estables para integraciones externas."""
+
+    def __init__(self, request):
+        self.request = request
+
+    def serialize_list_item(self, product):
+        """Devuelve la informacion resumida de un producto."""
+        image_url = self._build_media_url(product.imagen)
+
+        return {
+            'id': product.id,
+            'name': product.nombre,
+            'slug': product.slug,
+            'description': product.descripcion,
+            'price': str(product.precio),
+            'brand': product.marca.nombre,
+            'category': product.categoria.nombre,
+            'image': image_url,
+            'image_url': image_url,
+            'detail_url': self._build_product_detail_url(product.slug),
+        }
+
+    def serialize_detail(self, product):
+        """Devuelve la informacion completa de un producto."""
+        image_url = self._build_media_url(product.imagen)
+        stock_items = sorted(
+            product.stock_por_talla.all(),
+            key=lambda item: (
+                SIZE_ORDER.index(item.talla)
+                if item.talla in SIZE_ORDER
+                else len(SIZE_ORDER)
+            ),
+        )
+
+        return {
+            'id': product.id,
+            'name': product.nombre,
+            'slug': product.slug,
+            'description': product.descripcion,
+            'price': str(product.precio),
+            'brand': {
+                'name': product.marca.nombre,
+                'slug': product.marca.slug,
+            },
+            'category': {
+                'name': product.categoria.nombre,
+                'slug': product.categoria.slug,
+            },
+            'image': image_url,
+            'image_url': image_url,
+            'stock_total': product.stock_total,
+            'stock_by_size': [
+                {'size': item.talla, 'quantity': item.cantidad}
+                for item in stock_items
+            ],
+            'images': [
+                {
+                    'url': self._build_media_url(image.imagen),
+                    'order': image.orden,
+                    'is_main': image.es_principal,
+                }
+                for image in product.imagenes.all()
+            ],
+        }
+
+    def _build_media_url(self, image_field):
+        if not image_field:
+            return None
+        return self.request.build_absolute_uri(image_field.url)
+
+    def _build_product_detail_url(self, slug):
+        return self.request.build_absolute_uri(
+            reverse('products_api:product_detail', kwargs={'slug': slug})
+        )

--- a/products/api_urls.py
+++ b/products/api_urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import ProductApiDetailView, ProductApiListView
+
+app_name = 'products_api'
+
+urlpatterns = [
+    path('products/', ProductApiListView.as_view(), name='product_list'),
+    path('products/<slug:slug>/', ProductApiDetailView.as_view(), name='product_detail'),
+]

--- a/products/tests.py
+++ b/products/tests.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.test import override_settings
 from django.urls import reverse
 
 from .models import Categoria, Marca, Producto, StockPorTalla
@@ -146,6 +147,7 @@ class ProductCatalogTest(ProductTestMixin, TestCase):
         self.assertEqual([item.talla for item in response.context['inventory_items']], ['XS', 'M'])
 
 
+@override_settings(ALLOWED_HOSTS=['testserver'])
 class ProductApiTest(ProductTestMixin, TestCase):
     def setUp(self):
         self.category, self.brand, self.product = self.create_base_product()
@@ -157,12 +159,24 @@ class ProductApiTest(ProductTestMixin, TestCase):
         )
 
     def test_product_api_list_is_public_and_returns_active_products(self):
-        response = self.client.get(reverse('products:api_product_list'))
+        response = self.client.get(reverse('products_api:product_list'))
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(len(payload['results']), 1)
         self.assertEqual(payload['results'][0]['slug'], self.product.slug)
+        self.assertEqual(
+            payload['results'][0]['detail_url'],
+            f'http://testserver{reverse("products_api:product_detail", args=[self.product.slug])}',
+        )
+
+    def test_public_product_service_uses_public_route(self):
+        response = self.client.get(reverse('products_api:product_list'))
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['results'][0]['name'], self.product.nombre)
+        self.assertIn('/api/public/products/', payload['results'][0]['detail_url'])
 
     def test_product_api_filters_results(self):
         _, _, expensive_product = self.create_base_product(
@@ -173,7 +187,7 @@ class ProductApiTest(ProductTestMixin, TestCase):
         StockPorTalla.objects.create(producto=expensive_product, talla='L', cantidad=2)
 
         response = self.client.get(
-            reverse('products:api_product_list'),
+            reverse('products_api:product_list'),
             {
                 'q': 'Test',
                 'category': self.category.slug,
@@ -188,19 +202,20 @@ class ProductApiTest(ProductTestMixin, TestCase):
         self.assertEqual(slugs, [self.product.slug])
 
     def test_product_api_detail_returns_product_data(self):
-        response = self.client.get(reverse('products:api_product_detail', args=[self.product.slug]))
+        response = self.client.get(reverse('products_api:product_detail', args=[self.product.slug]))
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload['slug'], self.product.slug)
         self.assertEqual(payload['brand']['slug'], self.brand.slug)
+        self.assertEqual(payload['stock_total'], 5)
         self.assertEqual(payload['stock_by_size'], [{'size': 'M', 'quantity': 5}])
 
     def test_product_api_detail_returns_json_404_for_inactive_or_missing_product(self):
         inactive_response = self.client.get(
-            reverse('products:api_product_detail', args=[self.inactive_product.slug])
+            reverse('products_api:product_detail', args=[self.inactive_product.slug])
         )
-        missing_response = self.client.get(reverse('products:api_product_detail', args=['missing']))
+        missing_response = self.client.get(reverse('products_api:product_detail', args=['missing']))
 
         self.assertEqual(inactive_response.status_code, 404)
         self.assertEqual(missing_response.status_code, 404)

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,7 +1,5 @@
 from django.urls import path
 from .views import (
-    ProductApiDetailView,
-    ProductApiListView,
     ProductDetailView,
     ProductListView,
 )
@@ -9,8 +7,6 @@ from .views import (
 app_name = 'products'
 
 urlpatterns = [
-    path('api/products/', ProductApiListView.as_view(), name='api_product_list'),
-    path('api/products/<slug:slug>/', ProductApiDetailView.as_view(), name='api_product_detail'),
     path('', ProductListView.as_view(), name='product_list'),
     path('category/<slug:category_slug>/', ProductListView.as_view(), name='product_list_by_category'),
     path('<slug:slug>/', ProductDetailView.as_view(), name='product_detail'),

--- a/products/views.py
+++ b/products/views.py
@@ -5,6 +5,7 @@ from django.views import View
 from django.views.generic import DetailView, ListView
 
 from .constants import SIZE_ORDER
+from .api_serializers import ProductApiSerializer
 from .models import Categoria, Producto, StockPorTalla
 from .repositories import ProductoRepository
 
@@ -90,6 +91,7 @@ class ProductDetailView(DetailView):
 class ProductApiListView(View):
     def get(self, request, *args, **kwargs):
         repository = ProductoRepository()
+        serializer = ProductApiSerializer(request)
         products = repository.buscar(
             query=request.GET.get('q'),
             categoria=request.GET.get('category'),
@@ -99,61 +101,17 @@ class ProductApiListView(View):
             sort=request.GET.get('sort'),
         )
 
-        data = [
-            {
-                'id': product.id,
-                'name': product.nombre,
-                'slug': product.slug,
-                'price': str(product.precio),
-                'brand': product.marca.nombre,
-                'category': product.categoria.nombre,
-                'image': product.imagen.url if product.imagen else None,
-            }
-            for product in products
-        ]
+        data = [serializer.serialize_list_item(product) for product in products]
         return JsonResponse({'results': data})
 
 
 class ProductApiDetailView(View):
     def get(self, request, slug, *args, **kwargs):
         repository = ProductoRepository()
+        serializer = ProductApiSerializer(request)
         try:
             product = repository.obtener_activo_por_slug(slug)
         except Producto.DoesNotExist:
             return JsonResponse({'detail': 'Producto no encontrado.'}, status=404)
 
-        stock_items = sorted(
-            product.stock_por_talla.all(),
-            key=lambda item: SIZE_ORDER.index(item.talla)
-            if item.talla in SIZE_ORDER
-            else len(SIZE_ORDER),
-        )
-        data = {
-            'id': product.id,
-            'name': product.nombre,
-            'slug': product.slug,
-            'description': product.descripcion,
-            'price': str(product.precio),
-            'brand': {
-                'name': product.marca.nombre,
-                'slug': product.marca.slug,
-            },
-            'category': {
-                'name': product.categoria.nombre,
-                'slug': product.categoria.slug,
-            },
-            'image': product.imagen.url if product.imagen else None,
-            'stock_by_size': [
-                {'size': item.talla, 'quantity': item.cantidad}
-                for item in stock_items
-            ],
-            'images': [
-                {
-                    'url': image.imagen.url,
-                    'order': image.orden,
-                    'is_main': image.es_principal,
-                }
-                for image in product.imagenes.all()
-            ],
-        }
-        return JsonResponse(data)
+        return JsonResponse(serializer.serialize_detail(product))


### PR DESCRIPTION
Move the product JSON service from /shop/api/products/ to /api/public/products/ and extract product serialization for external consumers.

BREAKING CHANGE: /shop/api/products/ is no longer registered.