### PR TITLE
feat(orders): add external shipping rate provider

### DIFF
--- a/HMA_AS/settings.py
+++ b/HMA_AS/settings.py
@@ -170,3 +170,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGIN_URL = 'accounts:login'
 LOGIN_REDIRECT_URL = 'core:home'
 LOGOUT_REDIRECT_URL = 'core:home'
+
+# Shipping provider configuration.
+# "external" consumes a public exchange-rate API and falls back to the fixed
+# value if the service is unavailable.
+SHIPPING_RATE_PROVIDER = os.environ.get('SHIPPING_RATE_PROVIDER', 'external')
+EXCHANGE_RATE_API_URL = os.environ.get('EXCHANGE_RATE_API_URL', 'https://open.er-api.com/v6/latest/USD')
+BASE_SHIPPING_USD = os.environ.get('BASE_SHIPPING_USD', '4.00')
+FIXED_SHIPPING_RATE = os.environ.get('FIXED_SHIPPING_RATE', '15000.00')
+SHIPPING_API_TIMEOUT = int(os.environ.get('SHIPPING_API_TIMEOUT', '3'))

--- a/orders/services.py
+++ b/orders/services.py
@@ -4,14 +4,8 @@ from django.utils.translation import gettext_lazy as _
 from cart.cart import Cart
 from cart.db_backend import DatabaseCartBackend
 from .models import Orden, ItemOrden
+from .shipping import ShippingRateProviderFactory
 from products.services import InventoryService
-
-
-class MockShippingCalculator:
-    @staticmethod
-    def calculate(direccion):
-        from decimal import Decimal
-        return Decimal("15.00")
 
 
 class OrdenService:
@@ -29,7 +23,8 @@ class OrdenService:
         if len(session_cart) == 0:
             raise ValueError(_("El carrito está vacío."))
 
-        costo_envio = MockShippingCalculator.calculate(datos_envio.get('direccion_envio', ''))
+        shipping_provider = ShippingRateProviderFactory.create()
+        costo_envio = shipping_provider.calculate(datos_envio)
 
         # 1. Crear Orden
         orden = Orden.objects.create(

--- a/orders/shipping.py
+++ b/orders/shipping.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+import json
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+from django.conf import settings
+
+
+class ShippingRateProvider(ABC):
+    """Abstraccion para calcular el costo de envio de una orden."""
+
+    @abstractmethod
+    def calculate(self, shipping_data):
+        raise NotImplementedError
+
+
+class FixedShippingRateProvider(ShippingRateProvider):
+    """Proveedor local para entornos sin Internet o como respaldo."""
+
+    def __init__(self, amount=None):
+        self.amount = Decimal(str(amount or getattr(settings, "FIXED_SHIPPING_RATE", "15000.00")))
+
+    def calculate(self, shipping_data):
+        return self.amount
+
+
+class ExternalExchangeRateShippingRateProvider(ShippingRateProvider):
+    """
+    Calcula el envio consumiendo un API externo de tasas de cambio.
+
+    La tarifa base esta en USD y se convierte a COP con la respuesta de
+    open.er-api.com. Si el servicio no responde, usa el proveedor fijo.
+    """
+
+    def __init__(self, fallback=None):
+        self.api_url = getattr(settings, "EXCHANGE_RATE_API_URL", "https://open.er-api.com/v6/latest/USD")
+        self.base_amount_usd = Decimal(str(getattr(settings, "BASE_SHIPPING_USD", "4.00")))
+        self.timeout = getattr(settings, "SHIPPING_API_TIMEOUT", 3)
+        self.fallback = fallback or FixedShippingRateProvider()
+
+    def calculate(self, shipping_data):
+        try:
+            exchange_rate = self._fetch_cop_rate()
+        except (HTTPError, URLError, TimeoutError, ValueError, KeyError, InvalidOperation, json.JSONDecodeError):
+            return self.fallback.calculate(shipping_data)
+
+        amount = self.base_amount_usd * exchange_rate
+        return amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    def _fetch_cop_rate(self):
+        with urlopen(self.api_url, timeout=self.timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        rate = Decimal(str(payload["rates"]["COP"]))
+        if rate <= 0:
+            raise ValueError("La tasa COP recibida no es valida.")
+        return rate
+
+
+class ShippingRateProviderFactory:
+    @staticmethod
+    def create():
+        provider_name = getattr(settings, "SHIPPING_RATE_PROVIDER", "external").lower()
+        providers = {
+            "external": ExternalExchangeRateShippingRateProvider,
+            "fixed": FixedShippingRateProvider,
+        }
+        provider_class = providers.get(provider_name, ExternalExchangeRateShippingRateProvider)
+        return provider_class()

--- a/orders/tests.py
+++ b/orders/tests.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from cart.cart import Cart
@@ -41,6 +41,7 @@ class OrderTestMixin:
         }
 
 
+@override_settings(SHIPPING_RATE_PROVIDER='fixed', FIXED_SHIPPING_RATE='15000.00')
 class CheckoutIntegrationTest(OrderTestMixin, TestCase):
     def setUp(self):
         self.user = self.create_user()
@@ -69,6 +70,55 @@ class CheckoutIntegrationTest(OrderTestMixin, TestCase):
 
         self.assertRedirects(response, reverse('cart:detail'))
         self.assertEqual(Orden.objects.count(), 0)
+
+    def test_checkout_creates_paid_order_with_fixed_shipping_provider(self):
+        session = self.client.session
+        session[Cart.SESSION_KEY] = {
+            f'{self.product.id}:M': {
+                'producto_id': str(self.product.id),
+                'talla': 'M',
+                'cantidad': 1,
+                'precio_unitario': str(self.product.precio),
+            }
+        }
+        session.save()
+
+        response = self.client.post(reverse('orders:checkout'), self.valid_checkout_data())
+
+        order = Orden.objects.get()
+        self.assertRedirects(response, reverse('orders:detalle_orden', args=[order.id]))
+        self.assertEqual(order.estado, Orden.EstadoOrden.PAGADA)
+        self.assertEqual(order.costo_envio, Decimal('15000.00'))
+        self.assertEqual(order.monto_total, Decimal('15100.00'))
+
+
+class ShippingRateProviderTest(OrderTestMixin, TestCase):
+    @override_settings(
+        SHIPPING_RATE_PROVIDER='external',
+        BASE_SHIPPING_USD='4.00',
+        EXCHANGE_RATE_API_URL='https://example.test/latest/USD',
+    )
+    def test_external_provider_consumes_exchange_rate_api(self):
+        from unittest.mock import patch
+
+        from orders.shipping import ShippingRateProviderFactory
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+            def read(self):
+                return b'{"rates": {"COP": 4000}}'
+
+        with patch('orders.shipping.urlopen', return_value=FakeResponse()) as urlopen_mock:
+            provider = ShippingRateProviderFactory.create()
+            cost = provider.calculate(self.valid_checkout_data())
+
+        urlopen_mock.assert_called_once()
+        self.assertEqual(cost, Decimal('16000.00'))
 
 
 class OrderPermissionTest(OrderTestMixin, TestCase):


### PR DESCRIPTION
Implements an external shipping cost provider using a public exchange-rate API and applies dependency inversion with a common ShippingRateProvider interface plus fixed and external implementations.